### PR TITLE
field-properties: maintain selected field properties list

### DIFF
--- a/js/reducers/index.js
+++ b/js/reducers/index.js
@@ -161,7 +161,8 @@ function user(state = {
 function fieldProperties(state={
   isFetching: false,
   loaded: false,
-  items: []
+  items: [],
+  selectedItems: []
 }, action) {
   const AGGREGATIONS = [
     {
@@ -182,19 +183,34 @@ function fieldProperties(state={
   ];
   switch (action.type) {
     case SELECT_FIELD_PROPERTY:
-      var { items } = state;
+      var { items, selectedItems } = state;
 
-      const newSelectedIndex = state.items.findIndex((property, i, props) =>
+      const itemIndex = state.items.findIndex((property, i, props) =>
         property.id == action.selectedFieldPropertyId
       );
 
-      if (newSelectedIndex >= 0) {
-        items[newSelectedIndex].selected = !items[newSelectedIndex].selected;
+      if (itemIndex >= 0) {
+        items[itemIndex].selected = !items[itemIndex].selected;
+
+        const selectedItemsItemIndex = state.selectedItems.findIndex((property, i, props) =>
+          property.id == action.selectedFieldPropertyId
+        );
+
+        if (selectedItemsItemIndex >= 0) {
+          selectedItems.splice(selectedItemsItemIndex, 1);
+        }
+        else {
+          const item = items[itemIndex];
+          selectedItems.push({
+            id: item.id,
+            name: item.name
+          });
+        }
       }
 
-      return { ...state, items: items };
+      return { ...state, items: items, selectedItems: selectedItems };
     case SELECT_AGGREGATION_FUNCTION:
-      var { items } = state;
+      var { items, selectedItems } = state;
 
       const selectedAggregationFunctionFieldPropertyIndex = state.items.findIndex((property, i, props) =>
         property.id == action.selectedAggregationFunctionFieldPropertyId
@@ -211,9 +227,15 @@ function fieldProperties(state={
         if (selectedAggregationIndex >= 0) {
           items[selectedAggregationFunctionFieldPropertyIndex].splitMenu = aggregations;
         }
+
+        const aggregationValue = aggregations[selectedAggregationIndex].value;
+        const selectedItemsItemIndex = state.selectedItems.findIndex((property, i, props) =>
+          property.id == action.selectedAggregationFunctionFieldPropertyId
+        );
+        selectedItems[selectedItemsItemIndex].aggregation = aggregationValue;
       }
 
-      return { ...state, items: items };
+      return { ...state, items: items, selectedItems: selectedItems };
     case REQUEST_FIELD_PROPERTIES:
       return { ...state, isFetching: true };
     case RECEIVE_FIELD_PROPERTIES:


### PR DESCRIPTION
hmm, not sure this is really necessary…
@kevinzenghu what’s the reasoning for this vs maintaining a `.selected`
property?
