### PR TITLE
dataset-inspect: fix dataset column ordering by using Maps instead of Objects

### DIFF
--- a/public/js/actions/ActionHelpers.js
+++ b/public/js/actions/ActionHelpers.js
@@ -1,14 +1,14 @@
+function formatRow(columnNames, row) {
+  var newRow = new Map();
+
+  columnNames.forEach((columnName, j) =>
+    newRow.set(`${ columnName.replace(/[.]/g, '_') }`, row[j])
+  );
+
+  return newRow;
+}
+
 export function formatTableData(columnNames, data) {
-  function formatRow(columns, row) {
-    var newRow = {};
-
-    columns.forEach((column, j) =>
-      newRow[`${ column.replace(/[.]/g, '_') }`] = row[j]
-    );
-
-    return newRow;
-  }
-
   return data.map((row) =>
     formatRow(columnNames, row)
   );

--- a/public/js/components/Datasets/DatasetDataGrid.js
+++ b/public/js/components/Datasets/DatasetDataGrid.js
@@ -44,13 +44,13 @@ export default class DatasetDataGrid extends Component {
 
       const createHeaderCell = ((key, i) => createCell(key, i, key, createHeaderCellContent));
 
-      const headerRow = Object.keys(dataset.data[0]).map(createHeaderCell);
+      const headerRow = [...dataset.data[0].keys()].map(createHeaderCell);
 
       dataRows = dataset.data.map(function(row, i) {
-        const createDataCell = ((key, j) => createCell(key, j, row[key], createDataCellContent));
+        const createDataCell = ((key, j) => createCell(key, j, row.get(key), createDataCellContent));
         return {
           rowType: 'data',
-          items: Object.keys(row).map(createDataCell)
+          items: [...row.keys()].map(createDataCell)
         };
       });
 


### PR DESCRIPTION
/cc @kevinzenghu, fixed by using `Map`s which conserve insertion order.
